### PR TITLE
Add truth-or-dare animation wrappers to gameplay UI

### DIFF
--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -7,7 +7,7 @@ import { HUD } from '../ui/HUD';
 import { ChoiceGrid } from '../ui/ChoiceGrid';
 import { CardReveal } from '../ui/CardReveal';
 import { Dock } from '../ui/Dock';
-import { BeatReveal, WarmReveal, SparkOnSuccess } from '../ui/animations/VdAnim';
+import { BeatReveal, WarmReveal, SparkOnSuccess } from '@/ui/animations/VdAnim';
 
 
 interface GameScreenProps {
@@ -43,7 +43,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({
     gameState.currentCard ? 'revealed' : 'idle'
   );
   const [displayedCard, setDisplayedCard] = useState<Card | null>(gameState.currentCard);
-  const [ui, setUi] = useState({ sweeping: false, justFulfilled: false });
+  const [ui, setUi] = useState({ drawing: false, justFulfilled: false });
 
   const drawIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const drawTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -175,19 +175,19 @@ export const GameScreen: React.FC<GameScreenProps> = ({
     }
   }, [cardPhase, clearCardAnimationTimers, gameState.currentCard]);
 
-  const handleDraw = (kind: 'truth' | 'dare') => {
-    setUi(s => ({ ...s, sweeping: true }));
-    
-    // Vibração tátil se disponível
-    if ('vibrate' in navigator) {
-      navigator.vibrate([20, 50, 20]);
-    }
-    
+  const handleDraw = (kind: 'verdade' | 'desafio') => {
+    setUi((s) => ({ ...s, drawing: true }));
+    try {
+      navigator.vibrate?.(35);
+    } catch {}
     setTimeout(() => {
-      // Chama a lógica existente
-      handleDrawCard(kind);
-      setUi(s => ({ ...s, sweeping: false }));
-    }, 650); // duração do batimento
+      if (kind === 'verdade') {
+        handleDrawCard('truth');
+      } else {
+        handleDrawCard('dare');
+      }
+      setUi((s) => ({ ...s, drawing: false }));
+    }, 650);
   };
 
   const handleDrawCard = (type: 'truth' | 'dare') => {
@@ -221,8 +221,8 @@ export const GameScreen: React.FC<GameScreenProps> = ({
 
   const handleFulfill = () => {
     onFulfillCard(); // lógica existente
-    setUi(s => ({ ...s, justFulfilled: true }));
-    setTimeout(() => setUi(s => ({ ...s, justFulfilled: false })), 520);
+    setUi((s) => ({ ...s, justFulfilled: true }));
+    setTimeout(() => setUi((s) => ({ ...s, justFulfilled: false })), 520);
   };
 
   const drawHighlightText = finalDrawName ?? highlightedName ?? 'Girando nomes...';
@@ -273,51 +273,6 @@ export const GameScreen: React.FC<GameScreenProps> = ({
   const handleOpenReset = () => setShowResetConfirm(true);
 
   return (
-    <div className="grid min-h-dvh grid-rows-[56px_auto_88px] overflow-hidden">
-      <div className="px-4 py-2">
-        {intensity && (
-          <HUD intensity={intensity} currentPlayerInitial={currentPlayerInitial} boostPoints={boostPoints} />
-        )}
-      </div>
-      <div className="overflow-hidden">
-        {cardPhase === 'idle' ? (
-          <BeatReveal run={ui.sweeping}>
-          <BeatReveal run={ui.sweeping}>
-            <ChoiceGrid
-              onTruth={() => handleDraw('truth')}
-              onDare={() => handleDraw('dare')}
-              disabled={!canDrawCard}
-            />
-          </BeatReveal>
-          </BeatReveal>
-        ) : (
-          <SparkOnSuccess success={ui.justFulfilled}>
-            <WarmReveal show={!!activeCard}>
-          <SparkOnSuccess success={ui.justFulfilled}>
-            <WarmReveal show={!!activeCard}>
-              <CardReveal
-                cardText={activeCard?.text ?? ''}
-                deckTotal={deckSummary}
-                pileCount={pileCount}
-                hasBoost={hasBoost}
-                onFulfill={handleFulfill}
-                onPass={onPassCard}
-                canResolve={canResolveCard}
-                isLoading={isCardLoading}
-              />
-            </WarmReveal>
-          </SparkOnSuccess>
-            </WarmReveal>
-          </SparkOnSuccess>
-        )}
-      </div>
-      <div>
-        <Dock onCreate={handleOpenCreate} onDeck={handleOpenDeck} onReset={handleOpenReset} canCreate={Boolean(currentPlayer)} />
-      </div>
-    </div>
-  );
-
-  return (
     <>
       <div className="grid min-h-dvh grid-rows-[56px_auto_88px] overflow-hidden">
         <div className="px-4 py-2">
@@ -327,10 +282,10 @@ export const GameScreen: React.FC<GameScreenProps> = ({
         </div>
         <div className="overflow-hidden">
           {cardPhase === 'idle' ? (
-            <BeatReveal run={ui.sweeping}>
+            <BeatReveal run={ui.drawing}>
               <ChoiceGrid
-                onTruth={() => handleDraw('truth')}
-                onDare={() => handleDraw('dare')}
+                onTruth={() => handleDraw('verdade')}
+                onDare={() => handleDraw('desafio')}
                 disabled={!canDrawCard}
               />
             </BeatReveal>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import '@/styles/animations.css';
 import { AppErrorBoundary } from '@/components/AppErrorBoundary';
 
 createRoot(document.getElementById('root')!).render(

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -1,4 +1,4 @@
-/* Sorteio — BATIMENTO (3 pulsos + flip leve) */
+/* Sorteio — BATIMENTO (3 pulsos) */
 @keyframes vd-beat {
   0%, 100% { transform: scale(1); filter: saturate(1); }
   20% { transform: scale(1.03); box-shadow: 0 10px 40px rgba(255,46,126,.25); }
@@ -6,69 +6,37 @@
   60% { transform: scale(1.03); }
   80% { transform: scale(1); }
 }
-
 @keyframes vd-flip {
   0% { transform: rotateY(10deg); }
   100% { transform: rotateY(0); }
 }
-
-.vd-beat { 
-  animation: vd-beat 0.6s ease-in-out 1; 
-}
-
-.vd-flip { 
-  animation: vd-flip 0.18s ease-out 1; 
-  transform-style: preserve-3d; 
-}
+.vd-beat { animation: vd-beat 0.6s ease-in-out 1; }
+.vd-flip { animation: vd-flip 0.18s ease-out 1; transform-style: preserve-3d; }
 
 /* Reveal — RESPIRAÇÃO QUENTE (blur→nítido + levantar) */
 @keyframes vd-warmReveal {
-  from { 
-    opacity: 0; 
-    transform: translateY(12px); 
-    filter: blur(6px); 
-  }
-  to { 
-    opacity: 1; 
-    transform: translateY(0); 
-    filter: blur(0); 
-  }
+  from { opacity: 0; transform: translateY(12px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
 }
+.vd-warm { animation: vd-warmReveal .32s cubic-bezier(.2,.8,.2,1) both; }
 
-.vd-warm { 
-  animation: vd-warmReveal .32s cubic-bezier(.2,.8,.2,1) both; 
-}
-
-/* Consequência — FAGULHA (stroke correndo) */
+/* Consequência — FAGULHA (stroke correndo na borda) */
 @keyframes vd-spark {
   0%   { background-position: 0% 0%;   opacity: 0.9; }
   60%  { background-position: 150% 0%; opacity: 1; }
   100% { background-position: 200% 0%; opacity: 0; }
 }
-
-.vd-spark {
-  position: relative;
-}
-
-.vd-spark::after {
-  content: "";
-  position: absolute; 
-  inset: 0; 
-  border-radius: 20px; 
-  pointer-events: none;
-  padding: 1px; 
-  background: linear-gradient(90deg, transparent, #C400FF, #FF2E7E, #FF6B4A, transparent);
+.vd-spark { position: relative; }
+.vd-spark::after{
+  content:""; position:absolute; inset:0; border-radius:20px; pointer-events:none;
+  padding:1px; background:
+   linear-gradient(90deg, transparent, #C400FF, #FF2E7E, #FF6B4A, transparent);
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor; 
-  mask-composite: exclude;
-  background-size: 200% 100%;
-  animation: vd-spark .5s linear 1;
+  -webkit-mask-composite: xor; mask-composite: exclude;
+  background-size: 200% 100%; animation: vd-spark .5s linear 1;
 }
 
-/* Acessibilidade & prefers-reduced-motion */
+/* Acessibilidade */
 @media (prefers-reduced-motion: reduce) {
-  .vd-beat, .vd-flip, .vd-warm, .vd-spark { 
-    animation-duration: .01ms !important; 
-    animation-iteration-count: 1 !important; 
-  }
+  .vd-beat, .vd-flip, .vd-warm, .vd-spark { animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
 }

--- a/src/ui/animations/VdAnim.tsx
+++ b/src/ui/animations/VdAnim.tsx
@@ -1,30 +1,16 @@
 import React from 'react';
 
 export function BeatReveal({ run, children }: { run: boolean; children: React.ReactNode }) {
-  return (
-    <div className={run ? 'vd-beat vd-flip' : ''}>
-      {children}
-    </div>
-  );
+  return <div className={run ? 'vd-beat vd-flip' : ''}>{children}</div>;
 }
 
 export function WarmReveal({ show, children }: { show: boolean; children: React.ReactNode }) {
-  return (
-    <div className={show ? 'vd-warm' : 'opacity-0'}>
-      {children}
-    </div>
-  );
+  return <div className={show ? 'vd-warm' : 'opacity-0'}>{children}</div>;
 }
 
-/** Aplica a "Fagulha" ao container quando success=true */
-export function SparkOnSuccess({ success, children, className = '' }: {
-  success: boolean; 
-  children: React.ReactNode; 
-  className?: string;
-}) {
-  return (
-    <div className={`${className} ${success ? 'vd-spark' : ''}`}>
-      {children}
-    </div>
-  );
+/** Aplica “Fagulha” quando success=true (ex.: após Cumprir) */
+export function SparkOnSuccess({
+  success, children, className = ''
+}: { success: boolean; children: React.ReactNode; className?: string; }) {
+  return <div className={`${className} ${success ? 'vd-spark' : ''}`}>{children}</div>;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,7 +43,7 @@ export default {
         card: 'var(--radius-card)',
       },
       boxShadow: {
-        heat: 'var(--shadow-heat)',
+        heat: '0 6px 24px rgba(255,46,126,.30)',
         'heat-pulse': '0 6px 24px rgba(255,46,126,.30)',
         boost: 'var(--glow-boost)',
         holo: 'var(--shadow-holo)',


### PR DESCRIPTION
## Summary
- add reusable beat, warm reveal, and spark animation wrappers with shared CSS keyframes
- integrate the animation wrappers into the game screen draw and fulfill flows with UI state handling
- ensure tailwind heat shadow matches the new glow styling and load the animation styles globally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d484983430832686fa2705a7f75e25