### PR TITLE
Implement cooldown tick handling and point delta sequencing

### DIFF
--- a/src/components/ChooseNextCardModal.tsx
+++ b/src/components/ChooseNextCardModal.tsx
@@ -13,7 +13,7 @@ interface ChooseNextCardModalProps {
   state: GameState;
   chooserId: PlayerId;
   optionsShown?: number;
-  dispatch: (action: Action) => void;
+  dispatch: (action: Action) => void | Promise<void>;
   onCardCreated?: (card: Card) => void;
 }
 
@@ -111,7 +111,7 @@ export function ChooseNextCardModal({
     }
 
     const card = createCardLocal(state, { type: newCardType, text: trimmed, createdBy: chooserId });
-    dispatch({ type: 'CARD_CREATED_LOCAL', card });
+    void dispatch({ type: 'CARD_CREATED_LOCAL', card });
     onCardCreated?.(card);
     setCandidates(prev => [card, ...prev.filter(c => c.id !== card.id)]);
     setSelectedCardId(card.id);
@@ -121,7 +121,7 @@ export function ChooseNextCardModal({
     setActionError(null);
   };
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (!chooser) {
       setActionError('Jogador inválido.');
       return;
@@ -149,7 +149,8 @@ export function ChooseNextCardModal({
 
     if (!selectedCardId) {
       if (candidates.length === 0) {
-        dispatch({ type: 'POWER_CHOOSE_NEXT_REFUND', chooserId });
+        const refundResult = dispatch({ type: 'POWER_CHOOSE_NEXT_REFUND', chooserId });
+        await Promise.resolve(refundResult);
         handleClose();
         return;
       }
@@ -162,7 +163,7 @@ export function ChooseNextCardModal({
       return;
     }
 
-    dispatch({
+    const result = dispatch({
       type: 'POWER_CHOOSE_NEXT_COMMIT',
       payload: {
         chooserId,
@@ -170,6 +171,7 @@ export function ChooseNextCardModal({
         chosenCardId: selectedCardId,
       },
     });
+    await Promise.resolve(result);
     handleClose();
   };
 

--- a/src/components/PointsBadge.tsx
+++ b/src/components/PointsBadge.tsx
@@ -18,7 +18,7 @@ export function PointsBadge({ points, lastDelta = null, className }: PointsBadge
   }, [lastDelta]);
 
   return (
-    <div className={`relative inline-flex items-center justify-center ${className ?? ''}`}>
+    <div className={`relative z-30 inline-flex items-center justify-center ${className ?? ''}`}>
       <div className="rounded-2xl border border-white/10 bg-bg-900/70 px-4 py-2 shadow-inner">
         <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60">Pontos</span>
         <div className="text-3xl font-bold leading-none text-white">{points}</div>

--- a/src/ui/CardReveal.tsx
+++ b/src/ui/CardReveal.tsx
@@ -5,8 +5,8 @@ interface CardRevealProps {
   deckTotal: string;
   pileCount: number;
   hasBoost: boolean;
-  onFulfill: () => void;
-  onPass: () => void;
+  onFulfill: () => void | Promise<void>;
+  onPass: () => void | Promise<void>;
   canResolve: boolean;
   isLoading?: boolean;
 }


### PR DESCRIPTION
## Summary
- make the choose power dispatcher await point delta animations before continuing and keep deck removals in sync
- trigger the cooldown tick when a turn ends via fulfill or pass and update the roulette overlay layering
- allow asynchronous modal dispatches and elevate the points badge z-index so deltas remain visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d731624ff483268e5de0f33e1e3994