### PR TITLE
Add annual pass paywall Next.js UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,54 @@
-# Verdade ou Consequência — Guia de Identidade Visual
+# Boltz Passe Anual – UI de Paywall
 
-Este documento resume como aplicar e manter a identidade "Verdade ou Consequência" dentro do projeto. Toda a lógica do jogo permanece intocada: concentre-se apenas na camada visual.
+Interface em Next.js + TypeScript + Tailwind CSS para o fluxo de paywall do Passe Anual. Tudo aqui é UI-only, com funções stub para o time Boltz conectar Stripe e autenticação depois.
 
-## Fontes oficiais
-- **Títulos:** [Bebas Neue](https://fonts.google.com/specimen/Bebas+Neue)
-- **Corpo/UI:** [Plus Jakarta Sans](https://fonts.google.com/specimen/Plus+Jakarta+Sans)
-- **Destaques:** [Playfair Display Italic](https://fonts.google.com/specimen/Playfair+Display)
+## Pré-requisitos
 
-As fontes são importadas em `index.html` e aplicadas via classes utilitárias (`font-display`, `font-sans`, `font-accent`).
+- Node.js 18+
+- npm, pnpm ou yarn
 
-## Tokens globais
-Todos os tokens estão centralizados em [`src/styles/tokens.css`](src/styles/tokens.css) e expostos ao Tailwind (`theme.extend`). Utilize **sempre** os tokens ao criar novas superfícies, gradientes ou estados.
+## Como rodar
 
-| Categoria | Tokens principais |
-|-----------|------------------|
-| Cores base | `--color-primary-300/500/700`, `--color-secondary-300/500/700`, `--color-accent-500` |
-| Superfícies | `--color-bg-900`, `--color-bg-800`, `--color-border`, `--overlay-veil` |
-| Texto | `--color-text`, `--color-text-2` |
-| Níveis | `--level-leve`, `--level-medio`, `--level-pesado`, `--level-extremo` |
-| Gradientes | `--grad-heat`, `--glow-dare`, `--grad-overlay` |
-| Tipografia | `--font-display`, `--font-body`, `--font-accent` |
-| Forma & efeitos | `--radius-pill`, `--radius-card`, `--shadow-heat`, `--focus-glow` |
-| Outros | `--button-height`, `--texture-noise` |
+Instale as dependências e suba o servidor de desenvolvimento:
 
-## Utilitários Tailwind personalizados
-- **Cores:** `bg-primary-500`, `text-text-subtle`, `border-border`, `bg-level-leve`, etc.
-- **Raios:** `rounded-pill` e `rounded-card` para botões/cards.
-- **Sombras:** `shadow-heat` adiciona o brilho oficial (combine com `[--focus-shadow:var(--shadow-heat)]` para preservar a sombra em foco).
-- **Gradientes:** `bg-grad-heat` e `bg-glow-dare` aplicam os gradientes oficiais.
+```bash
+pnpm install
+pnpm dev
+```
 
-## Padrões de componentes
-- **Botão primário:** `class="flex h-[var(--button-height)] items-center justify-center gap-3 rounded-pill bg-grad-heat px-6 text-text shadow-heat [--focus-shadow:var(--shadow-heat)]"`
-- **Botão secundário:** `class="rounded-pill border border-border bg-bg-800/70 text-text hover:border-primary-500"`
-- **Chip de nível:** `class="rounded-pill px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-text bg-level-<nivel>"`
-- **Card base:** `class="relative overflow-hidden rounded-card border border-border bg-bg-900/70 p-8 shadow-heat"`
+Também funciona com npm ou yarn:
 
-## Estados e acessibilidade
-- **Foco:** já configurado globalmente com `box-shadow: var(--focus-glow)`; lembre-se de definir `[--focus-shadow:var(--shadow-heat)]` em elementos com sombra permanente.
-- **Contraste:** utilize `text-text` para textos importantes e `text-text-subtle` para legendas.
-- **Áreas clicáveis:** mantenha altura mínima de `h-12` (ou `h-[var(--button-height)]`) para ações primárias.
+```bash
+npm install
+npm run dev
+# ou
+yarn install
+yarn dev
+```
 
-## Estrutura visual
-- O fundo base usa `var(--color-bg-900)` + `--grad-overlay` + `--texture-noise` (já aplicado em `src/index.css`).
-- Sobreposições como modais usam `bg-[var(--overlay-veil)]`.
-- Cartas e telas principais possuem uma **barra de nível** (`bg-level-*`) no topo para comunicar a intensidade atual.
+A aplicação fica disponível em `http://localhost:3000`.
 
-Siga estas diretrizes ao criar novas telas, estados ou componentes. Qualquer cor ou efeito adicional deve ser derivado dos tokens acima para preservar a coerência da marca.
+## Fluxo de integração (Boltz)
+
+As páginas e componentes expõem props/funções para plugar integrações reais:
+
+- `PaywallSheet` recebe `onStartCheckout()` – conectar com Stripe Checkout.
+- `AuthPrompt` (e o próprio `PaywallSheet`) usam `onSignInWithGoogle()` e `onSignInWithEmail()` – conectar com o provedor de autenticação desejado.
+- O estado `isAuthenticated` deve ser atualizado após o login bem-sucedido.
+- O estado `hasAccess` deve ser atualizado após o retorno positivo do checkout.
+- Páginas de retorno do Stripe:
+  - `pages/checkout/sucesso.tsx` → usar como `success_url`.
+  - `pages/checkout/cancelado.tsx` → usar como `cancel_url`.
+
+> **TODOs marcados** no código indicam os pontos exatos para plugar as integrações.
+
+## Estrutura de UI
+
+- `/` – demo com os botões "Criar Carta" e "Escolher Destino". Ambos usam o gate `UseSpecialGate` para abrir o paywall quando necessário.
+- `components/PaywallSheet` – paywall acessível com foco preso, botões de login e CTA principal.
+- `components/AuthPrompt` – prompt visual para login (sem Firebase).
+- `components/UseSpecialGate` – wrapper para ações especiais.
+- `components/ui/Button` e `components/ui/Sheet` – camada de UI reutilizável (botões e sheet/modal responsivo).
+- `pages/checkout/sucesso` e `pages/checkout/cancelado` – telas estáticas pós-checkout.
+
+Tudo está pronto para mobile-first e responsivo via Tailwind.

--- a/components/AuthPrompt.tsx
+++ b/components/AuthPrompt.tsx
@@ -1,0 +1,39 @@
+import { Button } from "./ui/Button";
+
+type AuthPromptProps = {
+  onSignInWithGoogle: () => void;
+  onSignInWithEmail: () => void;
+};
+
+export const AuthPrompt = ({
+  onSignInWithGoogle,
+  onSignInWithEmail
+}: AuthPromptProps) => {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-neutral-600">
+        Faça login rapidinho para liberar o Passe Anual.
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onSignInWithGoogle}
+          fullWidth
+        >
+          Entrar com Google
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onSignInWithEmail}
+          fullWidth
+        >
+          Entrar com Email
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export type { AuthPromptProps };

--- a/components/PaywallSheet.tsx
+++ b/components/PaywallSheet.tsx
@@ -1,0 +1,103 @@
+import { useRef } from "react";
+import { AuthPrompt } from "./AuthPrompt";
+import { Button } from "./ui/Button";
+import { Sheet } from "./ui/Sheet";
+
+type PaywallSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  isAuthenticated: boolean;
+  hasAccess: boolean;
+  onSignInWithGoogle: () => void; // TODO: Boltz - wire Google Auth
+  onSignInWithEmail: () => void; // TODO: Boltz - wire Email Auth
+  onStartCheckout: () => void; // TODO: Boltz - wire Stripe Checkout
+};
+
+const benefits = [
+  "Crie cartas personalizadas e salve para outras noites",
+  "Escolha o destino e direcione a história",
+  "Acesso para a sala inteira quando você é o host"
+];
+
+const titleId = "paywall-title";
+
+export const PaywallSheet = ({
+  open,
+  onClose,
+  isAuthenticated,
+  hasAccess,
+  onSignInWithEmail,
+  onSignInWithGoogle,
+  onStartCheckout
+}: PaywallSheetProps) => {
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      labelledBy={titleId}
+      initialFocusRef={primaryButtonRef}
+    >
+      <div className="space-y-6">
+        <header className="space-y-2">
+          <h2 id={titleId} className="text-xl font-semibold text-neutral-900">
+            Libere as Ações Especiais por 1 ano
+          </h2>
+          <p className="text-sm text-neutral-600">
+            As Ações Especiais fazem o jogo ficar com a cara de vocês. Libere por
+            1 ano com preço de lançamento.
+          </p>
+        </header>
+
+        <div className="rounded-2xl border border-neutral-200 bg-neutral-50 p-4 sm:p-5">
+          <div className="flex flex-wrap items-end gap-3">
+            <span className="text-sm text-neutral-500 line-through">R$ 59,90</span>
+            <span className="text-3xl font-semibold text-primary">R$ 29,90</span>
+            <span className="text-xs font-medium uppercase tracking-wide text-primary">
+              Promo de lançamento
+            </span>
+          </div>
+        </div>
+
+        <ul className="space-y-3 text-sm text-neutral-700">
+          {benefits.map((benefit) => (
+            <li key={benefit} className="flex items-start gap-2">
+              <span aria-hidden className="mt-1 h-2 w-2 rounded-full bg-primary" />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
+
+        {!hasAccess && !isAuthenticated && (
+          <AuthPrompt
+            onSignInWithGoogle={onSignInWithGoogle}
+            onSignInWithEmail={onSignInWithEmail}
+          />
+        )}
+
+        <Button
+          ref={primaryButtonRef}
+          type="button"
+          onClick={() => {
+            if (!isAuthenticated) {
+              onSignInWithGoogle();
+              return;
+            }
+
+            onStartCheckout();
+          }}
+          fullWidth
+        >
+          Liberar agora
+        </Button>
+
+        <footer className="text-center text-xs text-neutral-500">
+          Pagamento via Stripe (Pix e Cartão).
+        </footer>
+      </div>
+    </Sheet>
+  );
+};
+
+export type { PaywallSheetProps };

--- a/components/UseSpecialGate.tsx
+++ b/components/UseSpecialGate.tsx
@@ -1,0 +1,46 @@
+import {
+  cloneElement,
+  isValidElement,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode
+} from "react";
+
+type UseSpecialGateProps = {
+  isAuthenticated: boolean;
+  hasAccess: boolean;
+  onRequestPaywall: () => void;
+  children: ReactNode;
+};
+
+export const UseSpecialGate = ({
+  isAuthenticated: _isAuthenticated,
+  hasAccess,
+  onRequestPaywall,
+  children
+}: UseSpecialGateProps) => {
+  if (!isValidElement(children)) {
+    return null;
+  }
+
+  const child = children as ReactElement<{ onClick?: (event: MouseEvent<HTMLElement>) => void }>;
+
+  return cloneElement(child, {
+    onClick: (event: MouseEvent<HTMLElement>) => {
+      if (hasAccess) {
+        child.props.onClick?.(event);
+
+        if (!event.defaultPrevented) {
+          console.log("Ação especial liberada!");
+        }
+
+        return;
+      }
+
+      event.preventDefault();
+      onRequestPaywall();
+    }
+  });
+};
+
+export type { UseSpecialGateProps };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,47 @@
+import clsx from "clsx";
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type DetailedHTMLProps
+} from "react";
+
+type ButtonVariant = "primary" | "secondary" | "ghost";
+
+type ButtonProps = DetailedHTMLProps<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+};
+
+const baseStyles =
+  "inline-flex items-center justify-center rounded-lg border text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60";
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary: "bg-primary text-white border-transparent hover:bg-primary/90",
+  secondary:
+    "bg-white text-neutral-900 border border-neutral-200 hover:border-neutral-300 hover:bg-neutral-50",
+  ghost: "bg-transparent border-transparent text-neutral-700 hover:bg-neutral-100"
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = "primary", fullWidth, className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={clsx(
+          baseStyles,
+          variantStyles[variant],
+          fullWidth && "w-full",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export type { ButtonProps };

--- a/components/ui/Sheet.tsx
+++ b/components/ui/Sheet.tsx
@@ -1,0 +1,133 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+  type RefObject
+} from "react";
+import { createPortal } from "react-dom";
+
+type SheetProps = {
+  open: boolean;
+  onClose: () => void;
+  labelledBy?: string;
+  children: ReactNode;
+  initialFocusRef?: RefObject<HTMLElement>;
+  closeOnOverlayClick?: boolean;
+  closeOnEsc?: boolean;
+};
+
+const focusableSelectors =
+  'a[href], button, textarea, input[type="text"], input[type="email"], input[type="tel"], select, [tabindex]:not([tabindex="-1"])';
+
+export const Sheet = ({
+  open,
+  onClose,
+  labelledBy,
+  children,
+  initialFocusRef,
+  closeOnOverlayClick = true,
+  closeOnEsc = true
+}: SheetProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  const handleFocusTrap = useCallback(
+    (event: KeyboardEvent) => {
+      if (!containerRef.current || event.key !== "Tab") {
+        return;
+      }
+
+      const focusableEls = Array.from(
+        containerRef.current.querySelectorAll<HTMLElement>(focusableSelectors)
+      ).filter((el) => !el.hasAttribute("disabled"));
+
+      if (focusableEls.length === 0) {
+        event.preventDefault();
+        containerRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableEls[0];
+      const lastElement = focusableEls[focusableEls.length - 1];
+
+      if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    lastFocusedElementRef.current = document.activeElement as HTMLElement;
+
+    const focusTarget = initialFocusRef?.current || containerRef.current;
+
+    const timer = window.setTimeout(() => {
+      focusTarget?.focus();
+    }, 0);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (closeOnEsc && event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+
+      handleFocusTrap(event);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener("keydown", handleKeyDown);
+      lastFocusedElementRef.current?.focus();
+      lastFocusedElementRef.current = null;
+    };
+  }, [closeOnEsc, handleFocusTrap, initialFocusRef, onClose, open]);
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center">
+      <div
+        className="sheet-overlay"
+        onClick={() => {
+          if (closeOnOverlayClick) {
+            onClose();
+          }
+        }}
+      />
+      <div
+        aria-labelledby={labelledBy}
+        role="dialog"
+        aria-modal
+        className="sheet-container"
+        ref={containerRef}
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export type { SheetProps };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,36 +1,27 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "boltz-pass-interface",
   "private": true,
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.1",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "lint": "eslint .",
-    "preview": "vite preview",
-    "build:test": "tsc -p tsconfig.tests.json && node scripts/rename-build-test.mjs",
-    "test": "npm run build:test && node --test tests"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.57.4",
-    "lucide-react": "^0.344.0",
+    "next": "14.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "clsx": "^2.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "eslint": "^9.9.1",
-    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-    "eslint-plugin-react-refresh": "^0.4.11",
-    "globals": "^15.9.0",
+    "eslint-config-next": "14.2.3",
     "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1",
-    "typescript": "^5.5.3",
-    "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "tailwindcss": "^3.4.9",
+    "typescript": "^5.5.3"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,21 @@
+import type { AppProps } from "next/app";
+import Head from "next/head";
+import "../styles/globals.css";
+
+const App = ({ Component, pageProps }: AppProps) => {
+  return (
+    <>
+      <Head>
+        <title>Boltz Passe Anual</title>
+        <meta
+          name="description"
+          content="Libere as Ações Especiais do jogo com o Passe Anual."
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+};
+
+export default App;

--- a/pages/checkout/cancelado.tsx
+++ b/pages/checkout/cancelado.tsx
@@ -1,0 +1,28 @@
+import Head from "next/head";
+import Link from "next/link";
+
+const CheckoutCanceledPage = () => {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-50 px-4 py-16">
+      <Head>
+        <title>Pagamento cancelado</title>
+      </Head>
+      <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 text-center shadow-modal">
+        <h1 className="text-2xl font-semibold text-neutral-900">
+          Pagamento cancelado.
+        </h1>
+        <p className="text-neutral-600">
+          Você pode tentar novamente quando quiser.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex w-full items-center justify-center rounded-lg border border-neutral-200 bg-white px-4 py-3 text-sm font-medium text-neutral-900 transition hover:border-neutral-300 hover:bg-neutral-50"
+        >
+          Voltar
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default CheckoutCanceledPage;

--- a/pages/checkout/sucesso.tsx
+++ b/pages/checkout/sucesso.tsx
@@ -1,0 +1,29 @@
+import Head from "next/head";
+import Link from "next/link";
+
+const CheckoutSuccessPage = () => {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-50 px-4 py-16">
+      <Head>
+        <title>Passe Anual liberado</title>
+      </Head>
+      <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 text-center shadow-modal">
+        <h1 className="text-2xl font-semibold text-neutral-900">
+          Acesso liberado! Seu Passe Anual está ativo.
+        </h1>
+        <p className="text-neutral-600">
+          Agora você pode usar as Ações Especiais sem limites pelos próximos 12
+          meses.
+        </p>
+        <Link
+          href="/"
+          className="inline-flex w-full items-center justify-center rounded-lg bg-primary px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-primary/90"
+        >
+          Voltar ao jogo
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default CheckoutSuccessPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import Head from "next/head";
+import { PaywallSheet } from "../components/PaywallSheet";
+import { UseSpecialGate } from "../components/UseSpecialGate";
+import { Button } from "../components/ui/Button";
+
+const HomePage = () => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [hasAccess, setHasAccess] = useState(false);
+  const [paywallOpen, setPaywallOpen] = useState(false);
+
+  const onSignInWithGoogle = () => {
+    alert("TODO: integrar login Google");
+    setIsAuthenticated(true);
+  };
+
+  const onSignInWithEmail = () => {
+    alert("TODO: integrar login Email");
+    setIsAuthenticated(true);
+  };
+
+  const onStartCheckout = () => {
+    alert("TODO: integrar Stripe Checkout");
+    // TODO: Boltz - acionar checkout do Stripe e atualizar hasAccess após sucesso
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Head>
+        <title>Demo Ações Especiais</title>
+      </Head>
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-10 px-4 py-12">
+        <section className="space-y-3 text-center">
+          <p className="text-sm font-medium uppercase tracking-wide text-primary">
+            Passe Anual
+          </p>
+          <h1 className="text-3xl font-semibold text-neutral-900">
+            Demo das Ações Especiais
+          </h1>
+          <p className="text-neutral-600">
+            Tente usar uma ação especial para ver o paywall em ação.
+          </p>
+        </section>
+
+        <section className="grid gap-4 sm:grid-cols-2">
+          <UseSpecialGate
+            isAuthenticated={isAuthenticated}
+            hasAccess={hasAccess}
+            onRequestPaywall={() => setPaywallOpen(true)}
+          >
+            <Button type="button" fullWidth>
+              Criar Carta
+            </Button>
+          </UseSpecialGate>
+
+          <UseSpecialGate
+            isAuthenticated={isAuthenticated}
+            hasAccess={hasAccess}
+            onRequestPaywall={() => setPaywallOpen(true)}
+          >
+            <Button type="button" fullWidth>
+              Escolher Destino
+            </Button>
+          </UseSpecialGate>
+        </section>
+
+        <section className="space-y-2 rounded-2xl border border-dashed border-neutral-200 bg-white p-4 text-sm text-neutral-600">
+          <h2 className="text-base font-semibold text-neutral-900">
+            Como testar
+          </h2>
+          <ul className="list-inside list-disc space-y-1 text-left">
+            <li>Use os botões acima para abrir o paywall.</li>
+            <li>
+              Simule login clicando em um dos botões de entrada ou no CTA (isso
+              marca você como autenticado nesta demo).
+            </li>
+            <li>
+              Depois do login, clique em “Liberar agora” para ver o stub do
+              Stripe Checkout.
+            </li>
+          </ul>
+        </section>
+      </main>
+
+      <PaywallSheet
+        open={paywallOpen}
+        onClose={() => setPaywallOpen(false)}
+        isAuthenticated={isAuthenticated}
+        hasAccess={hasAccess}
+        onSignInWithGoogle={onSignInWithGoogle}
+        onSignInWithEmail={onSignInWithEmail}
+        onStartCheckout={onStartCheckout}
+      />
+    </div>
+  );
+};
+
+export default HomePage;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
+    autoprefixer: {}
+  }
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-neutral-50 text-neutral-900 antialiased;
+}
+
+a {
+  @apply text-primary hover:underline;
+}
+
+/* Utility classes for sheet/modal layout */
+.sheet-overlay {
+  @apply fixed inset-0 bg-neutral-900/50 backdrop-blur-sm transition-opacity;
+}
+
+.sheet-container {
+  @apply fixed left-1/2 bottom-0 top-auto w-full max-w-lg -translate-x-1/2 rounded-t-3xl bg-white p-6 shadow-sheet;
+  @apply sm:top-1/2 sm:bottom-auto sm:rounded-2xl sm:p-8 sm:shadow-modal sm:transform sm:-translate-y-1/2;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,37 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#4C51BF",
+          foreground: "#FFFFFF"
+        },
+        neutral: {
+          50: "#f8fafc",
+          100: "#f1f5f9",
+          200: "#e2e8f0",
+          300: "#cbd5f5",
+          400: "#94a3b8",
+          500: "#64748b",
+          600: "#475569",
+          700: "#334155",
+          800: "#1e293b",
+          900: "#0f172a"
+        }
+      },
+      borderRadius: {
+        xl: "1rem"
+      },
+      boxShadow: {
+        sheet: "0 -12px 32px rgba(15, 23, 42, 0.18)",
+        modal: "0 20px 60px rgba(15, 23, 42, 0.25)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,21 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- replace the previous Vite setup with a Next.js + Tailwind UI for the Passe Anual paywall demo
- add reusable UI primitives plus the AuthPrompt, PaywallSheet, and UseSpecialGate components wired with clear integration stubs
- create demo and checkout feedback pages alongside updated documentation for Boltz integrations

## Testing
- npm install --package-lock-only *(fails: registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83c5f19dc83269986a51d081205a8