### PR TITLE
Fix GameScreen useEffect deps and add ESLint ignore file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+.next
+node_modules
+tailwind.config.js
+postcss.config.js
+next.config.js
+**/*.config.js
+**/*.config.cjs
+**/*.config.mjs

--- a/src/components/GameScreen.tsx
+++ b/src/components/GameScreen.tsx
@@ -279,7 +279,7 @@ export const GameScreen: React.FC<GameScreenProps> = ({
 
   useEffect(() => {
     setPowerState(prev => syncPowerStateWithGame(prev, gameState));
-  }, [gameState.availableCards, gameState.intensity, gameState.players]);
+  }, [gameState]);
 
   const adjustPlayerPoints = useCallback(
     (playerId: string, delta: number) => {


### PR DESCRIPTION
## Summary
- update the GameScreen useEffect dependency array to include the full gameState so the hook reacts to state changes without lint warnings
- add a root .eslintignore so Tailwind and other config files no longer break lint during builds

## Testing
- npm run build *(fails: next not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d844422b548326ab62e49bbd7296e5