### PR TITLE
Fix Next.js build by scoping TypeScript checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 build-test
+tsconfig.tsbuildinfo
 *.local
 
 # Editor directories and files

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,9 +1,9 @@
-import clsx from "clsx";
 import {
   forwardRef,
   type ButtonHTMLAttributes,
   type DetailedHTMLProps
 } from "react";
+import { cn } from "../../lib/cn";
 
 type ButtonVariant = "primary" | "secondary" | "ghost";
 
@@ -30,7 +30,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button
         ref={ref}
-        className={clsx(
+        className={cn(
           baseStyles,
           variantStyles[variant],
           fullWidth && "w-full",

--- a/lib/cn.ts
+++ b/lib/cn.ts
@@ -1,0 +1,38 @@
+export type ClassValue =
+  | string
+  | number
+  | null
+  | undefined
+  | boolean
+  | ClassValue[]
+  | { [key: string]: boolean | string | number | null | undefined };
+
+const appendClassNames = (classes: string[], value: ClassValue): void => {
+  if (!value) {
+    return;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    classes.push(String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => appendClassNames(classes, item));
+    return;
+  }
+
+  if (typeof value === "object") {
+    Object.entries(value).forEach(([key, condition]) => {
+      if (condition) {
+        classes.push(key);
+      }
+    });
+  }
+};
+
+export const cn = (...values: ClassValue[]): string => {
+  const classes: string[] = [];
+  values.forEach((value) => appendClassNames(classes, value));
+  return classes.join(" ").trim();
+};

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "next": "14.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "clsx": "^2.0.0"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.18",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,14 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "react", "react-dom"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "pages/**/*.ts",
+    "pages/**/*.tsx",
+    "components/**/*.ts",
+    "components/**/*.tsx",
+    "lib/**/*.ts",
+    "lib/**/*.tsx"
+  ],
+  "exclude": ["node_modules", "src", "tests", "build-test", "scripts"]
 }


### PR DESCRIPTION
## Summary
- scope the root tsconfig to the Next.js pages/components so legacy Vite sources stop breaking `next build`
- replace the `clsx` dependency with a lightweight internal helper and update imports
- ignore the generated `tsconfig.tsbuildinfo` artifact

## Testing
- Not run (next binary is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d84500fb0c83268f471d64d609e83b