### PR TITLE
Add premium entitlement flow with Firebase auth and Stripe

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/entitlements/{doc} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if false;
+    }
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "functions",
+  "main": "lib/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "deploy": "npm run build && firebase deploy --only functions"
+  },
+  "dependencies": {
+    "firebase-functions": "^5.1.0",
+    "firebase-admin": "^12.6.0",
+    "stripe": "^16.5.0",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.3",
+    "ts-node": "^10.9.2",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21"
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,151 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import Stripe from 'stripe';
+import cors from 'cors';
+import type { Request, Response } from 'express';
+
+admin.initializeApp();
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2024-06-20' });
+
+const PRICE_ID = process.env.STRIPE_PRICE_ID as string;
+const SUCCESS_URL = process.env.SUCCESS_URL as string;
+const CANCEL_URL = process.env.CANCEL_URL as string;
+const WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET as string;
+
+const CORS = cors({ origin: true });
+
+async function verifyAuth(req: Request): Promise<string> {
+  const authHeader = req.headers.authorization || '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.substring(7) : null;
+  if (!token) throw new Error('unauthorized');
+  const decoded = await admin.auth().verifyIdToken(token);
+  return decoded.uid;
+}
+
+export const createCheckoutSession = functions.region('southamerica-east1').https.onRequest(async (req: Request, res: Response) => {
+  CORS(req, res, async () => {
+    try {
+      if (req.method !== 'POST') return res.status(405).send('Method Not Allowed');
+      const uid = await verifyAuth(req);
+      const { promoCode } = (req.body || {}) as { promoCode?: string };
+
+      const userRef = admin.firestore().doc(`users/${uid}`);
+      const userSnap = await userRef.get();
+      let customerId: string | undefined = userSnap.get('stripeCustomerId');
+
+      if (!customerId) {
+        const userRecord = await admin.auth().getUser(uid).catch(() => null);
+        const email = userRecord?.email || undefined;
+        const customer = await stripe.customers.create({ email, metadata: { uid } });
+        customerId = customer.id;
+        await userRef.set({ stripeCustomerId: customerId }, { merge: true });
+        await admin.firestore().doc(`stripeCustomers/${customerId}`).set({ uid }, { merge: true });
+      }
+
+      const params: Stripe.Checkout.SessionCreateParams = {
+        mode: 'subscription',
+        customer: customerId,
+        client_reference_id: uid,
+        success_url: SUCCESS_URL + '?session_id={CHECKOUT_SESSION_ID}',
+        cancel_url: CANCEL_URL,
+        line_items: [{ price: PRICE_ID, quantity: 1 }],
+        allow_promotion_codes: true,
+        payment_method_types: ['card', 'boleto'],
+      };
+
+      if (promoCode) {
+        // promotion_code precisa existir no Stripe com esse code
+        // Alternativamente, use 'discounts: [{ coupon: "..." }]' se preferir cupom direto
+      }
+
+      const session = await stripe.checkout.sessions.create(params);
+      res.json({ url: session.url });
+    } catch (err: any) {
+      console.error(err);
+      res.status(400).json({ error: err.message || 'unknown_error' });
+    }
+  });
+});
+
+export const stripeWebhook = functions.region('southamerica-east1').https.onRequest(async (req: Request, res: Response) => {
+  const sig = req.headers['stripe-signature'] as string;
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(req.rawBody, sig, WEBHOOK_SECRET);
+  } catch (err: any) {
+    console.error('Webhook signature verification failed.', err.message);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed':
+      case 'invoice.paid':
+      case 'customer.subscription.updated': {
+        const obj = event.data.object as any;
+        const customerId = (obj.customer?.id ?? obj.customer) as string;
+        const sub = obj.subscription ? await stripe.subscriptions.retrieve(obj.subscription) : null;
+        let uid: string | undefined;
+
+        const stripeMap = await admin.firestore().doc(`stripeCustomers/${customerId}`).get();
+        uid = (stripeMap.exists && stripeMap.get('uid')) || (obj.client_reference_id as string);
+
+        if (!uid) {
+          console.warn('No uid found for event', event.id);
+          break;
+        }
+
+        const active = sub ? sub.status === 'active' || sub.status === 'trialing' : true;
+        const periodEnd = sub?.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null;
+
+        await admin.firestore().doc(`users/${uid}`).set({ stripeCustomerId: customerId }, { merge: true });
+        await admin.firestore().doc(`users/${uid}/entitlements/specialActions`).set(
+          {
+            active,
+            currentPeriodEnd: periodEnd,
+            updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+          },
+          { merge: true }
+        );
+        break;
+      }
+      case 'customer.subscription.deleted': {
+        const sub = event.data.object as Stripe.Subscription;
+        const customerId = sub.customer as string;
+        const mapDoc = await admin.firestore().doc(`stripeCustomers/${customerId}`).get();
+        const uid = mapDoc.get('uid');
+        if (uid) {
+          await admin.firestore().doc(`users/${uid}/entitlements/specialActions`).set(
+            {
+              active: false,
+              currentPeriodEnd: new Date(sub.current_period_end * 1000).toISOString(),
+              updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            },
+            { merge: true }
+          );
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    res.json({ received: true });
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).send('webhook_handler_error');
+  }
+});
+
+export const checkEntitlement = functions.region('southamerica-east1').https.onRequest(async (req: Request, res: Response) => {
+  CORS(req, res, async () => {
+    try {
+      const uid = await verifyAuth(req);
+      const snap = await admin.firestore().doc(`users/${uid}/entitlements/specialActions`).get();
+      const data = snap.exists ? snap.data() : null;
+      res.json({ active: !!data?.active, expiresAt: data?.currentPeriodEnd || null });
+    } catch (err: any) {
+      res.status(400).json({ error: err.message || 'unknown_error' });
+    }
+  });
+});

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "@supabase/supabase-js": "^2.57.4",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "firebase": "^10.12.4",
+    "@stripe/stripe-js": "^2.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/ChooseNextCardModal.tsx
+++ b/src/components/ChooseNextCardModal.tsx
@@ -5,6 +5,7 @@ import type { PlayerId } from '@/models/players';
 import type { Action } from '@/state/chooseNextCardReducer';
 import { canTarget } from '@/state/chooseNextCardReducer';
 import { createCardLocal, getCandidateCards } from '@/services/cardsService';
+import { PremiumGate } from './PremiumGate';
 import type { CardType } from '@/models/cards';
 
 interface ChooseNextCardModalProps {
@@ -381,33 +382,35 @@ export function ChooseNextCardModal({
           >
             Cancelar
           </button>
-          <button
-            type="button"
-            onClick={handleConfirm}
-            className={`rounded-lg bg-accent-500 px-5 py-2 text-sm font-semibold text-bg-900 transition hover:bg-accent-400 disabled:cursor-not-allowed disabled:bg-white/20 disabled:text-white/50 ${
-              isSubmitting ? 'opacity-60 cursor-wait' : ''
-            }`}
-            disabled={
-              isSubmitting ||
-              !selectedCardId ||
-              !selectedTarget ||
-              !state.players[selectedTarget] ||
-              !chooser ||
-              chooser.points < 5 ||
-              cooldown > 0
-            }
-            aria-disabled={
-              isSubmitting ||
-              !selectedCardId ||
-              !selectedTarget ||
-              !state.players[selectedTarget] ||
-              !chooser ||
-              chooser.points < 5 ||
-              cooldown > 0
-            }
-          >
-            Confirmar
-          </button>
+          <PremiumGate>
+            {(canUse, openPaywall) => {
+              const isDisabled =
+                isSubmitting ||
+                !selectedCardId ||
+                !selectedTarget ||
+                !state.players[selectedTarget] ||
+                !chooser ||
+                chooser.points < 5 ||
+                cooldown > 0;
+              const handleClick = () => {
+                if (isDisabled) return;
+                return canUse ? handleConfirm() : openPaywall();
+              };
+              return (
+                <button
+                  type="button"
+                  onClick={handleClick}
+                  className={`rounded-lg bg-accent-500 px-5 py-2 text-sm font-semibold text-bg-900 transition hover:bg-accent-400 disabled:cursor-not-allowed disabled:bg-white/20 disabled:text-white/50 ${
+                    isSubmitting ? 'opacity-60 cursor-wait' : ''
+                  }`}
+                  disabled={isDisabled}
+                  aria-disabled={isDisabled}
+                >
+                  Confirmar
+                </button>
+              );
+            }}
+          </PremiumGate>
         </footer>
       </div>
     </div>

--- a/src/components/CreateCardModal.tsx
+++ b/src/components/CreateCardModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Player, IntensityLevel } from '../types/game';
 import { Zap, X, Plus, Sparkles, Loader2 } from 'lucide-react';
 import { GameCard } from './GameCard';
+import { PremiumGate } from './PremiumGate';
 
 interface CreateCardModalProps {
   currentPlayer: Player;
@@ -37,9 +38,7 @@ export const CreateCardModal: React.FC<CreateCardModalProps> = ({
 
   const canApplyBoost = currentPlayer.boostPoints >= 2;
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
+  const submitCard = async () => {
     if (!cardText.trim()) {
       alert('Digite o texto da carta!');
       return;
@@ -99,7 +98,7 @@ export const CreateCardModal: React.FC<CreateCardModalProps> = ({
           </div>
 
           <form
-            onSubmit={handleSubmit}
+            onSubmit={e => e.preventDefault()}
             className="grid gap-6 px-6 py-6 lg:grid-cols-[1.05fr_1fr]"
           >
             <div className="space-y-6">
@@ -277,14 +276,22 @@ export const CreateCardModal: React.FC<CreateCardModalProps> = ({
                 >
                   Cancelar
                 </button>
-                <button
-                  type="submit"
-                  disabled={!cardText.trim() || isSubmitting}
-                  className="flex h-12 items-center justify-center gap-2 rounded-pill bg-grad-heat px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus size={18} />}
-                  {isSubmitting ? 'Criando...' : 'Criar carta'}
-                </button>
+                <PremiumGate>
+                  {(canUse, openPaywall) => (
+                    <button
+                      type="button"
+                      disabled={!cardText.trim() || isSubmitting}
+                      onClick={() => {
+                        if (!cardText.trim() || isSubmitting) return;
+                        return canUse ? submitCard() : openPaywall();
+                      }}
+                      className="flex h-12 items-center justify-center gap-2 rounded-pill bg-grad-heat px-4 text-sm font-semibold uppercase tracking-[0.2em] text-text shadow-heat [--focus-shadow:var(--shadow-heat)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus size={18} />}
+                      {isSubmitting ? 'Criando...' : 'Criar carta'}
+                    </button>
+                  )}
+                </PremiumGate>
               </div>
             </div>
           </form>

--- a/src/components/PaywallModal.tsx
+++ b/src/components/PaywallModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { useEntitlement } from '@/hooks/useEntitlement';
+
+type Props = { isOpen: boolean; onClose: () => void; promoCode?: string };
+
+export function PaywallModal({ isOpen, onClose, promoCode }: Props) {
+  const { loginGoogle, loginApple, loginEmailLink, openCheckout } = useEntitlement();
+  const [email, setEmail] = useState('');
+  const [step, setStep] = useState<'auth' | 'loading' | 'error'>('auth');
+  const [err, setErr] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const doCheckout = async () => {
+    try {
+      setStep('loading');
+      setInfo(null);
+      await openCheckout(promoCode);
+    } catch (e: any) {
+      setErr(e?.message || 'Falha ao abrir o checkout');
+      setInfo(null);
+      setStep('error');
+    }
+  };
+
+  const afterLogin = async (fn: () => Promise<any>) => {
+    try {
+      setStep('loading');
+      setErr(null);
+      setInfo(null);
+      const result = await fn();
+      if (result === 'link_sent') {
+        setInfo('Enviamos um link mágico para o seu e-mail. Abra-o pelo mesmo dispositivo para continuar.');
+        setStep('auth');
+        return;
+      }
+      await doCheckout();
+    } catch (e: any) {
+      setErr(e?.message || 'Falha na autenticação');
+      setInfo(null);
+      setStep('error');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="w-full max-w-md rounded-2xl bg-bg-800 p-6">
+        <h2 className="text-xl font-semibold text-white">Libere as Ações Especiais por 1 ano</h2>
+        <p className="mt-1 text-sm text-white/70">Crie cartas personalizadas, escolha o destino e desbloqueie animações exclusivas.</p>
+        <div className="my-4 rounded-lg bg-bg-900 p-3 text-sm">
+          <div>
+            <del>R$ 59,90</del> <strong>R$ 29,90</strong> (promo de lançamento)
+          </div>
+        </div>
+
+        {step === 'auth' && (
+          <>
+            {info && <p className="mb-3 rounded-lg bg-bg-900/80 p-3 text-sm text-white/80">{info}</p>}
+            <button className="mb-2 w-full rounded-xl bg-white py-2 text-black" onClick={() => afterLogin(() => loginGoogle())}>
+              Continuar com Google
+            </button>
+            <button className="mb-2 w-full rounded-xl bg-white py-2 text-black" onClick={() => afterLogin(() => loginApple())}>
+              Continuar com Apple
+            </button>
+            <div className="mt-2">
+              <label className="text-xs text-white/70">Ou e-mail (link mágico)</label>
+              <input
+                className="mt-1 w-full rounded-xl bg-bg-900 p-2"
+                placeholder="seu@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <button className="mt-2 w-full rounded-xl bg-accent-500 py-2" onClick={() => afterLogin(() => loginEmailLink(email))}>
+                Enviar link e continuar
+              </button>
+            </div>
+            <button className="mt-4 w-full rounded-xl bg-gradient-to-r from-pink-500 to-orange-400 py-2" onClick={doCheckout}>
+              Já tenho conta — Ir para o pagamento
+            </button>
+            <button className="mt-2 w-full text-sm text-white/60" onClick={onClose}>
+              Continuar grátis
+            </button>
+          </>
+        )}
+
+        {step === 'loading' && <p className="text-white/80">Preparando seu acesso seguro…</p>}
+        {step === 'error' && (
+          <>
+            <p className="text-red-400">{err}</p>
+            <button className="mt-3 w-full rounded-xl bg-bg-700 py-2" onClick={() => setStep('auth')}>
+              Tentar novamente
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PremiumGate.tsx
+++ b/src/components/PremiumGate.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import { useEntitlement } from '@/hooks/useEntitlement';
+import { PaywallModal } from './PaywallModal';
+
+type Props = { children: (canUse: boolean, openPaywall: () => void) => React.ReactNode; promoCode?: string };
+
+export function PremiumGate({ children, promoCode }: Props) {
+  const { active, loading } = useEntitlement();
+  const [open, setOpen] = useState(false);
+  const openPaywall = () => setOpen(true);
+  return (
+    <>
+      {children(!loading && active, openPaywall)}
+      <PaywallModal isOpen={open} onClose={() => setOpen(false)} promoCode={promoCode} />
+    </>
+  );
+}

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,11 +1,30 @@
+import { initializeApp } from 'firebase/app';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  OAuthProvider,
+  isSignInWithEmailLink,
+} from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
 export const firebaseConfig = {
-  apiKey: 'AIzaSyD6k5hRvxPpAp-k3Hhoifyt4LPp1E5Zo1Q',
-  authDomain: 'verdadeconsequencia.firebaseapp.com',
-  projectId: 'verdadeconsequencia',
-  storageBucket: 'verdadeconsequencia.firebasestorage.app',
-  messagingSenderId: '704487870593',
-  appId: '1:704487870593:web:f49d0203223fcf7abe7d80',
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN as string,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID as string,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID as string,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET as string,
 } as const;
+
+export const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+
+export const googleProvider = new GoogleAuthProvider();
+export const appleProvider = new OAuthProvider('apple.com');
+
+export const FUNCTIONS_BASE_URL = import.meta.env.VITE_FUNCTIONS_BASE_URL as string;
+
+export const isEmailLink = () => isSignInWithEmailLink(auth, window.location.href);
 
 export const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${firebaseConfig.projectId}/databases/(default)/documents`;
 

--- a/src/hooks/useEntitlement.ts
+++ b/src/hooks/useEntitlement.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  onAuthStateChanged,
+  signInWithPopup,
+  sendSignInLinkToEmail,
+  isSignInWithEmailLink,
+  signInWithEmailLink
+} from 'firebase/auth';
+import { auth, googleProvider, appleProvider } from '@/config/firebase';
+import { checkEntitlement, createCheckoutSession } from '@/services/entitlementApi';
+
+type Entitlement = { active: boolean; expiresAt?: string | null; loading: boolean };
+
+export function useEntitlement() {
+  const [state, setState] = useState<Entitlement>({ active: false, loading: true, expiresAt: null });
+
+  const refresh = useCallback(async () => {
+    try {
+      setState((s) => ({ ...s, loading: true }));
+      const data = await checkEntitlement();
+      setState({ active: !!data.active, expiresAt: data.expiresAt ?? null, loading: false });
+    } catch {
+      setState((s) => ({ ...s, loading: false }));
+    }
+  }, []);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, () => {
+      refresh().catch(() => {});
+    });
+    if (isSignInWithEmailLink(auth, window.location.href)) {
+      const email = window.localStorage.getItem('magic_email') || window.prompt('Confirme seu e-mail');
+      if (email) {
+        signInWithEmailLink(auth, email, window.location.href).finally(() => {
+          window.localStorage.removeItem('magic_email');
+        });
+      }
+    }
+    return () => unsub();
+  }, [refresh]);
+
+  const loginGoogle = async () => signInWithPopup(auth, googleProvider);
+  const loginApple = async () => signInWithPopup(auth, appleProvider);
+  const loginEmailLink = async (email: string, continueUrl?: string) => {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      throw new Error('Informe um e-mail válido');
+    }
+    await sendSignInLinkToEmail(auth, trimmed, {
+      url: continueUrl || window.location.href,
+      handleCodeInApp: true,
+    });
+    window.localStorage.setItem('magic_email', trimmed);
+    return 'link_sent' as const;
+  };
+
+  const openCheckout = async (promoCode?: string) => {
+    const { url } = await createCheckoutSession(promoCode);
+    window.location.href = url;
+  };
+
+  return { ...state, refresh, loginGoogle, loginApple, loginEmailLink, openCheckout };
+}

--- a/src/routes/CheckoutCancel.tsx
+++ b/src/routes/CheckoutCancel.tsx
@@ -1,0 +1,3 @@
+export default function CheckoutCancel() {
+  return <div className="p-6 text-white">Pagamento cancelado. Você pode tentar novamente quando quiser.</div>;
+}

--- a/src/routes/CheckoutSuccess.tsx
+++ b/src/routes/CheckoutSuccess.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useEntitlement } from '@/hooks/useEntitlement';
+
+export default function CheckoutSuccess() {
+  const { refresh } = useEntitlement();
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+  return <div className="p-6 text-white">Concluído! Seu Premium foi ativado. 🎉</div>;
+}

--- a/src/services/entitlementApi.ts
+++ b/src/services/entitlementApi.ts
@@ -1,0 +1,24 @@
+import { auth } from '@/config/firebase';
+
+const base = import.meta.env.VITE_FUNCTIONS_BASE_URL as string;
+
+async function authFetch(path: string, init?: RequestInit) {
+  const user = auth.currentUser;
+  if (!user) throw new Error('not_authenticated');
+  const token = await user.getIdToken();
+  const headers = new Headers(init?.headers || {});
+  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Content-Type', 'application/json');
+  const res = await fetch(`${base}${path}`, { ...init, headers });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function createCheckoutSession(promoCode?: string) {
+  const body = promoCode ? JSON.stringify({ promoCode }) : '{}';
+  return authFetch('/createCheckoutSession', { method: 'POST', body });
+}
+
+export async function checkEntitlement() {
+  return authFetch('/checkEntitlement', { method: 'GET' });
+}


### PR DESCRIPTION
## Summary
- configure Firebase app initialization and add an entitlement service + hook with paywall UI
- gate premium-only interactions for creating/choosing cards and add checkout feedback routes
- scaffold Cloud Functions project for Stripe checkout, entitlement webhooks, and Firestore rules

## Testing
- npm run build *(fails: missing firebase/stripe packages in environment registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d2ebe4d88326a2fdb22eca7c4074