### PR TITLE
fix: harden firebase bootstrap and surface boot errors

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -7,24 +7,52 @@ import {
 } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
+function requireEnv(name: string): string {
+  const v = (import.meta as any).env?.[name];
+  if (!v) {
+    // Log explícito e mantém app vivo
+    // Obs.: não lançamos exceção aqui para evitar “tela preta” por erro síncrono.
+    console.error(`[ENV MISSING] ${name} não definido. Configure as variáveis VITE_* no ambiente de produção.`);
+    return '';
+  }
+  return v as string;
+}
+
 export const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN as string,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID as string,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID as string,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET as string,
+  apiKey: requireEnv('VITE_FIREBASE_API_KEY'),
+  authDomain: requireEnv('VITE_FIREBASE_AUTH_DOMAIN'),
+  projectId: requireEnv('VITE_FIREBASE_PROJECT_ID'),
+  appId: requireEnv('VITE_FIREBASE_APP_ID'),
+  storageBucket: requireEnv('VITE_FIREBASE_STORAGE_BUCKET'),
 } as const;
 
-export const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+// Evita crash se env estiver faltando: só inicializa quando temos o mínimo
+const canInit =
+  firebaseConfig.apiKey &&
+  firebaseConfig.authDomain &&
+  firebaseConfig.projectId &&
+  firebaseConfig.appId;
+
+let app: ReturnType<typeof initializeApp> | null = null;
+try {
+  if (canInit) {
+    app = initializeApp(firebaseConfig);
+  } else {
+    console.warn('[Firebase] Variáveis incompletas: app não inicializado.');
+  }
+} catch (err) {
+  console.error('[Firebase] Falha ao inicializar:', err);
+}
+
+export const auth = app ? getAuth(app) : (null as any);
+export const db = app ? getFirestore(app) : (null as any);
 
 export const googleProvider = new GoogleAuthProvider();
 export const appleProvider = new OAuthProvider('apple.com');
 
-export const FUNCTIONS_BASE_URL = import.meta.env.VITE_FUNCTIONS_BASE_URL as string;
+export const FUNCTIONS_BASE_URL = requireEnv('VITE_FUNCTIONS_BASE_URL');
 
-export const isEmailLink = () => isSignInWithEmailLink(auth, window.location.href);
+export const isEmailLink = () => typeof window !== 'undefined' && isSignInWithEmailLink(auth, window.location.href);
 
 export const FIRESTORE_BASE_URL =
   `https://firestore.googleapis.com/v1/projects/${firebaseConfig.projectId}/databases/(default)/documents`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,31 +11,22 @@ function attachGlobalErrorBanner() {
     if (!el) {
       el = document.createElement('div');
       el.id = 'boot-error-banner';
-      el.style.position = 'fixed';
-      el.style.left = '0';
-      el.style.right = '0';
-      el.style.bottom = '0';
-      el.style.zIndex = '9999';
-      el.style.padding = '12px 16px';
-      el.style.background = 'rgba(192, 30, 30, .95)';
-      el.style.color = '#fff';
-      el.style.fontFamily = 'system-ui, -apple-system, Segoe UI, Roboto, Arial';
-      el.style.fontSize = '13px';
-      el.style.whiteSpace = 'pre-wrap';
+      Object.assign(el.style, {
+        position: 'fixed', left: '0', right: '0', bottom: '0', zIndex: '9999',
+        padding: '12px 16px', background: 'rgba(192,30,30,.95)', color: '#fff',
+        fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Arial', fontSize: '13px',
+        whiteSpace: 'pre-wrap'
+      } as CSSStyleDeclaration);
       document.body.appendChild(el);
     }
     el.textContent = `Erro de execução: ${msg}`;
   };
-
-  window.addEventListener('error', e => {
-    add(e?.error?.message || e?.message || 'erro desconhecido');
-  });
+  window.addEventListener('error', (e) => add(e?.error?.message || e?.message || 'erro desconhecido'));
   window.addEventListener('unhandledrejection', (e: any) => {
     const reason = e?.reason?.message || String(e?.reason || 'unhandledrejection');
     add(reason);
   });
 }
-
 attachGlobalErrorBanner();
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary
- add defensive env validation around firebase configuration to avoid hard crashes and keep REST base URL intact
- attach a global boot error banner so runtime failures surface to the user instead of leaving a blank screen

## Testing
- ⚠️ `npm install --no-progress` *(fails: 403 Forbidden fetching @eslint/js from registry in the execution environment)*
- ⚠️ `npm run dev` *(fails: `vite` not found because dependencies could not be installed in this environment)*
- ⚠️ `npm run build` *(fails: `vite` not found because dependencies could not be installed in this environment)*
- ⚠️ `npm run preview` *(fails: `vite` not found because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db256da2d48326afaa22935fa9d6e4