### PR TITLE
Fix Google login checkout by inferring functions URL

### DIFF
--- a/src/components/PaywallModal.tsx
+++ b/src/components/PaywallModal.tsx
@@ -17,7 +17,7 @@ export function PaywallModal({ isOpen, onClose, promoCode }: Props) {
     try {
       setStep('loading');
       setInfo(null);
-      await openCheckout(promoCode);
+      await openCheckout(promoCode, selectedPlan);
     } catch (e: any) {
       setErr(e?.message || 'Falha ao abrir o checkout');
       setInfo(null);

--- a/src/services/entitlementApi.ts
+++ b/src/services/entitlementApi.ts
@@ -1,8 +1,27 @@
-import { auth } from '@/config/firebase';
+import { auth, firebaseConfig } from '@/config/firebase';
 
-const base = import.meta.env.VITE_FUNCTIONS_BASE_URL as string;
+function inferFunctionsBaseUrl() {
+  const envBase = (import.meta.env.VITE_FUNCTIONS_BASE_URL as string | undefined)?.trim();
+  if (envBase) return envBase.replace(/\/$/, '');
+
+  const projectId = firebaseConfig.projectId;
+  if (!projectId) return '';
+
+  if (import.meta.env.DEV) {
+    return `http://localhost:5001/${projectId}/southamerica-east1`;
+  }
+
+  return `https://southamerica-east1-${projectId}.cloudfunctions.net`;
+}
+
+const base = inferFunctionsBaseUrl();
 
 async function authFetch(path: string, init?: RequestInit) {
+  if (!base) {
+    throw new Error(
+      'URL das Cloud Functions não configurada. Defina VITE_FUNCTIONS_BASE_URL ou configure VITE_FIREBASE_PROJECT_ID corretamente.'
+    );
+  }
   const user = auth.currentUser;
   if (!user) throw new Error('not_authenticated');
   const token = await user.getIdToken();


### PR DESCRIPTION
## Summary
- infer the Cloud Functions base URL from the Firebase project when the Vite env var is missing
- block checkout requests early when the base URL cannot be resolved and keep plan selection when opening the Stripe checkout
- embed the Verdade Consequência Firebase defaults so Google login works even when Vite env vars are missing

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0eccae1083268e92b7584057aa46