### PR TITLE
Add refreshEntitlement endpoint for immediate premium unlock

### DIFF
--- a/src/services/entitlementApi.ts
+++ b/src/services/entitlementApi.ts
@@ -90,3 +90,21 @@ export async function checkEntitlement() {
     { method: 'GET' }
   );
 }
+
+export async function refreshEntitlementRequest(idToken: string) {
+  if (!base) {
+    throw new Error(
+      'URL das Cloud Functions não configurada. Defina VITE_FUNCTIONS_BASE_URL ou configure VITE_FIREBASE_PROJECT_ID corretamente.'
+    );
+  }
+
+  const r = await fetch(`${base}/refreshEntitlement`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!r.ok) throw new Error(`refresh failed ${r.status}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary
- add a Cloud Function endpoint that refreshes a user's entitlement based on active Stripe subscriptions and updates Firestore
- expose a frontend helper to call the refresh endpoint with a Firebase ID token and invoke it after checkout success for instant access

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4637ef0348326b27202fec58b3cf7